### PR TITLE
Fix small Python 3 warnings

### DIFF
--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -1076,9 +1076,9 @@ class MailSenderConfigurationTab(gui_utilities.GladeGObject):
 			return True
 
 		message = 'SPF exists and the policy evaluates to: ' + spf_result
-		if spf_result is 'fail':
+		if spf_result == 'fail':
 			message = 'SPF exists with a hard fail, messages will probably be blocked.'
-		elif spf_result is 'softfail':
+		elif spf_result == 'softfail':
 			message = 'SPF exists with a soft fail, messages might be blocked.'
 		gui_utilities.show_dialog_info('SPF Check Results', self.parent, message)
 		return True


### PR DESCRIPTION
  /opt/king-phisher/king_phisher/client/tabs/mail.py:1079: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if spf_result is 'fail':
  /opt/king-phisher/king_phisher/client/tabs/mail.py:1081: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif spf_result is 'softfail':